### PR TITLE
Preallocate sID_all when not using outside group

### DIFF
--- a/renderer_api/get_pms_cross_layer.m
+++ b/renderer_api/get_pms_cross_layer.m
@@ -6,93 +6,93 @@ if nargin<5
 end
 
 %%%% uncomment if using Matlab 2017a
-%
-% urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesWith/%s', ...
-%    pm(1).server, pm(1).owner, pm(1).match_collection, sID1, sID2);
-% U = matlab.net.URI(urlChar);
-%
-% if numel(pm)>1
-%     data_options_str = '?';
-%     for ix = 2:numel(pm)
-%         if ix ==2
-%             data_options_str = [data_options_str 'mergeCollection=' pm(ix).match_collection];
-%         else
-%             data_options_str = [data_options_str '&mergeCollection=' pm(ix).match_collection];
-%         end
-%     end
-%     QPs = matlab.net.QueryParameter(data_options_str);
-%     U.Query = QPs;
-% end
-%
-% try
-%     jj = webread(char(U), wopts);
-% catch err_fetch_pm
-%     kk_disp_err(err_fetch_pm)
-%     pause(1);
-%     if strfind(err_fetch_pm.message,'Maximum variable size allowed by the function is exceeded')
-%         disp('trying again with websave');
-%         filename = ['large_pm_file_' num2str(randi(3000000)) '_' strrep(num2str(sum(clock)),'.','') '.json'];
-%         websave(filename,char(U), wopts);
-%         jj_cell_array = loadjson(filename);
-%         jj(numel(jj_cell_array),1)=struct('pGroupId',[],'pId',[],'qGroupId',[],'qId',[],'matches',[]);
-%         for i=1:numel(jj_cell_array)
-%             jj(i) = jj_cell_array{i};
-%         end
-%     else
-%         disp('trying again');
-%         jj = webread(char(U),wopts); % try again
-%     end
-% end
+
+ urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesWith/%s', ...
+    pm(1).server, pm(1).owner, pm(1).match_collection, sID1, sID2);
+ U = matlab.net.URI(urlChar);
+
+ if numel(pm)>1
+     data_options_str = '?';
+     for ix = 2:numel(pm)
+         if ix ==2
+             data_options_str = [data_options_str 'mergeCollection=' pm(ix).match_collection];
+         else
+             data_options_str = [data_options_str '&mergeCollection=' pm(ix).match_collection];
+         end
+     end
+     QPs = matlab.net.QueryParameter(data_options_str);
+     U.Query = QPs;
+ end
+
+ try
+     jj = webread(char(U), wopts);
+ catch err_fetch_pm
+     kk_disp_err(err_fetch_pm)
+     pause(1);
+     if strfind(err_fetch_pm.message,'Maximum variable size allowed by the function is exceeded')
+         disp('trying again with websave');
+         filename = ['large_pm_file_' num2str(randi(3000000)) '_' strrep(num2str(sum(clock)),'.','') '.json'];
+         websave(filename,char(U), wopts);
+         jj_cell_array = loadjson(filename);
+         jj(numel(jj_cell_array),1)=struct('pGroupId',[],'pId',[],'qGroupId',[],'qId',[],'matches',[]);
+         for i=1:numel(jj_cell_array)
+             jj(i) = jj_cell_array{i};
+         end
+     else
+         disp('trying again');
+         jj = webread(char(U),wopts); % try again
+     end
+ end
 
 
 %%%% uncomment if using 2016a
 % % %disp([sID{isix} ' ---- ' sID{jsix}]);
 % % %%jj = webread(urlChar, wopts);
-try
-  if outside_group
-    jj = [];
-  end
-  
-  for pix = numel(pm):-1:1
-    if outside_group
-      urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesOutsideGroup', ...
-			pm(pix).server, pm(pix).owner, ...
-			pm(pix).match_collection, sID1);
-      jj =[jj; webread(urlChar, wopts)];
+% try
+%   if outside_group
+%     jj = [];
+%   end
 
-    else
-      urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesWith/%s', ...
-			pm(pix).server, pm(pix).owner, ...
-			pm(pix).match_collection, sID1, sID2);
-      jj(pix) = webread(urlChar,wopts);
-    end
-  end
-catch err_fetch_pm
-    kk_disp_err(err_fetch_pm)
-    pause(1);
-    jj = [];
-    for pix = 1:numel(pm)
-        if outside_group
-            urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesOutsideGroup', ...
-                pm(pix).server, pm(pix).owner, pm(pix).match_collection, sID1);
-        else
-            urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesWith/%s', ...
-                pm(pix).server, pm(pix).owner, pm(pix).match_collection, sID1, sID2);
-        end
-        jj =[jj; webread(urlChar, wopts)];
-    end
-end
-if outside_group
-    if ~isempty(jj)
-        pGroupIds = cellfun(@str2num,{jj.pGroupId});
-        qGroupIds = cellfun(@str2num,{jj.qGroupId});
-        to_remove = (pGroupIds == str2num(sID1) & (qGroupIds<str2num(sID1) | qGroupIds>str2num(sID2))) |...
-            (qGroupIds == str2num(sID1) & (pGroupIds<str2num(sID1) | pGroupIds>str2num(sID2))); %make sure only taking correct pairs
-        jj(to_remove) = []; %Delete those outside range
-    end
-end
-if numel(pm)>1
-    jj = concatenate_point_match_sets(jj);
-end
-%%%%%%%%%%%%%%%
+%   for pix = numel(pm):-1:1
+%     if outside_group
+%       urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesOutsideGroup', ...
+% 			pm(pix).server, pm(pix).owner, ...
+% 			pm(pix).match_collection, sID1);
+%       jj =[jj; webread(urlChar, wopts)];
+
+%     else
+%       urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesWith/%s', ...
+% 			pm(pix).server, pm(pix).owner, ...
+% 			pm(pix).match_collection, sID1, sID2);
+%       jj(pix) = webread(urlChar,wopts);
+%     end
+%   end
+% catch err_fetch_pm
+%     kk_disp_err(err_fetch_pm)
+%     pause(1);
+%     jj = [];
+%     for pix = 1:numel(pm)
+%         if outside_group
+%             urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesOutsideGroup', ...
+%                 pm(pix).server, pm(pix).owner, pm(pix).match_collection, sID1);
+%         else
+%             urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesWith/%s', ...
+%                 pm(pix).server, pm(pix).owner, pm(pix).match_collection, sID1, sID2);
+%         end
+%         jj =[jj; webread(urlChar, wopts)];
+%     end
+% end
+% if outside_group
+%     if ~isempty(jj)
+%         pGroupIds = cellfun(@str2num,{jj.pGroupId});
+%         qGroupIds = cellfun(@str2num,{jj.qGroupId});
+%         to_remove = (pGroupIds == str2num(sID1) & (qGroupIds<str2num(sID1) | qGroupIds>str2num(sID2))) |...
+%             (qGroupIds == str2num(sID1) & (pGroupIds<str2num(sID1) | pGroupIds>str2num(sID2))); %make sure only taking correct pairs
+%         jj(to_remove) = []; %Delete those outside range
+%     end
+% end
+% if numel(pm)>1
+%     jj = concatenate_point_match_sets(jj);
+% end
+% %%%%%%%%%%%%%%%
 

--- a/renderer_api/get_pms_cross_layer.m
+++ b/renderer_api/get_pms_cross_layer.m
@@ -12,15 +12,17 @@ end
  U = matlab.net.URI(urlChar);
 
  if numel(pm)>1
-     data_options_str = '?';
-     for ix = 2:numel(pm)
-         if ix ==2
-             data_options_str = [data_options_str 'mergeCollection=' pm(ix).match_collection];
-         else
-             data_options_str = [data_options_str '&mergeCollection=' pm(ix).match_collection];
-         end
+   data_options_str(numel(pm)) = '';
+   data_options_str(1) = '?';
+   for ix = 2:numel(pm)
+     if ix ==2
+       data_options_str(ix) = 'mergeCollection=' pm(ix).match_collection;
+     else
+       data_options_str(ix) = '&mergeCollection=' pm(ix).match_collection;
      end
-     QPs = matlab.net.QueryParameter(data_options_str);
+   end
+   
+     QPs = matlab.net.QueryParameter(strjoin(data_options_str,''));
      U.Query = QPs;
  end
 

--- a/renderer_api/get_pms_cross_layer.m
+++ b/renderer_api/get_pms_cross_layer.m
@@ -54,13 +54,13 @@ try
   for pix = numel(pm):-1:1
     if outside_group
       urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesOutsideGroup', ...
-			pm(pix).server, pm(pix).owner,
+			pm(pix).server, pm(pix).owner, ...
 			pm(pix).match_collection, sID1);
       jj =[jj; webread(urlChar, wopts)];
 
     else
       urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesWith/%s', ...
-			pm(pix).server, pm(pix).owner,
+			pm(pix).server, pm(pix).owner, ...
 			pm(pix).match_collection, sID1, sID2);
       jj(pix) = webread(urlChar,wopts)
     end

--- a/renderer_api/get_pms_cross_layer.m
+++ b/renderer_api/get_pms_cross_layer.m
@@ -16,9 +16,9 @@ end
    data_options_str(1) = '?';
    for ix = 2:numel(pm)
      if ix ==2
-       data_options_str(ix) = 'mergeCollection=' pm(ix).match_collection;
+       data_options_str(ix) = strcat('mergeCollection=',pm(ix).match_collection);
      else
-       data_options_str(ix) = '&mergeCollection=' pm(ix).match_collection;
+       data_options_str(ix) = strcat('&mergeCollection=',pm(ix).match_collection);
      end
    end
    

--- a/renderer_api/get_pms_cross_layer.m
+++ b/renderer_api/get_pms_cross_layer.m
@@ -49,17 +49,22 @@ end
 % % %disp([sID{isix} ' ---- ' sID{jsix}]);
 % % %%jj = webread(urlChar, wopts);
 try
-    jj = [];
-    for pix = 1:numel(pm)
-        if outside_group
-            urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesOutsideGroup', ...
-                pm(pix).server, pm(pix).owner, pm(pix).match_collection, sID1);
-        else
-             urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesWith/%s', ...
-                pm(pix).server, pm(pix).owner, pm(pix).match_collection, sID1, sID2);
-        end
-        jj =[jj; webread(urlChar, wopts)];
+  jj = [];
+  
+  for pix = numel(pm):-1:1
+    if outside_group
+      urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesOutsideGroup', ...
+			pm(pix).server, pm(pix).owner,
+			pm(pix).match_collection, sID1);
+      jj =[jj; webread(urlChar, wopts)];
+
+    else
+      urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesWith/%s', ...
+			pm(pix).server, pm(pix).owner,
+			pm(pix).match_collection, sID1, sID2);
+      jj(pix) = webread(urlChar,wopts)
     end
+  end
 catch err_fetch_pm
     kk_disp_err(err_fetch_pm)
     pause(1);

--- a/renderer_api/get_pms_cross_layer.m
+++ b/renderer_api/get_pms_cross_layer.m
@@ -49,7 +49,9 @@ end
 % % %disp([sID{isix} ' ---- ' sID{jsix}]);
 % % %%jj = webread(urlChar, wopts);
 try
-  jj = [];
+  if outside_group
+    jj = [];
+  end
   
   for pix = numel(pm):-1:1
     if outside_group
@@ -62,7 +64,7 @@ try
       urlChar = sprintf('%s/owner/%s/matchCollection/%s/group/%s/matchesWith/%s', ...
 			pm(pix).server, pm(pix).owner, ...
 			pm(pix).match_collection, sID1, sID2);
-      jj(pix) = webread(urlChar,wopts)
+      jj(pix) = webread(urlChar,wopts);
     end
   end
 catch err_fetch_pm

--- a/solver/system_solve_affine_with_constraint.m
+++ b/solver/system_solve_affine_with_constraint.m
@@ -133,6 +133,7 @@ if ~isfield(opts, 'transfac'), opts.transfac = 1;end
 if ~isfield(opts, 'filter_point_matches'), opts.filter_point_matches = 1;end
 if ~isfield(opts, 'use_peg'), opts.use_peg = 0;end
 if ~isfield(opts, 'nbrs_step'), opts.nbrs_step = 1;end
+is ~isfield(opts, 'centre'), opts.centre = false;end
 
 
 err = [];
@@ -207,7 +208,11 @@ else
             H = j.height;
             for ix = 1:numel(tvalid)  % loop over tiles that are registered as having point-matches to other tiles
                 tix = tvalid(ix);
-                bb = [0 0 1;W 0 1;0 H 1;W H 1];  % base is 4 corner points
+                if opts.centre
+                    bb = [-W/2 -H/2 1; W/2 -H/2 1; -W/2 H/2 1; W/2 H/2 1];
+                else
+                    bb = [0 0 1;W 0 1;0 H 1;W H 1];  % base is 4 corner points
+                end
                 aa = [rand(opts.peg_npoints-4,1)*W rand(opts.peg_npoints-4,1)...
                     *H ones(opts.peg_npoints-4,1)]; % add additional point to top up to n
                 bo = [aa;bb];

--- a/solver/system_solve_affine_with_constraint.m
+++ b/solver/system_solve_affine_with_constraint.m
@@ -133,7 +133,7 @@ if ~isfield(opts, 'transfac'), opts.transfac = 1;end
 if ~isfield(opts, 'filter_point_matches'), opts.filter_point_matches = 1;end
 if ~isfield(opts, 'use_peg'), opts.use_peg = 0;end
 if ~isfield(opts, 'nbrs_step'), opts.nbrs_step = 1;end
-is ~isfield(opts, 'centre'), opts.centre = false;end
+if ~isfield(opts, 'centre'), opts.centre = false;end
 
 
 err = [];

--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -70,9 +70,7 @@ if ~opts.primenbr
   end
   for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
 			 %disp(['Setting up section: ' sID{ix}]);
-    if ~opts.outside_group
-      sID_all = cell(numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2,2);
-    end
+
 
     sID_all{count,1} = sID{ix};
     sID_all{count,2} = sID{ix};
@@ -115,7 +113,7 @@ if ~opts.primenbr
       end
     end
   end
-  if ~opts.outside_group && count ~= numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2 + 1
+  if ~opts.outside_group && count ~= numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs+1)/2 + 1
     sID_all = sID_all(1:count-1,1:2);
   end
 else

--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -63,7 +63,6 @@ else
 end
 ismontage = [];
 count  = 1;
-<<<<<<< HEAD
 
 if ~opts.primenbr
   if ~opts.outside_group

--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -102,6 +102,9 @@ for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
         end
     end
 end
+if ~opts.outside_group && count ~= numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2
+    sID_all = sID_all(1:count,2);
+end
 % clear sID
 % % perform pm requests
 

--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -164,7 +164,7 @@ M   = {};
 adj = {};
 W   = {};
 np = {};  % store a vector with number of points in point-matches (so we don't need to loop again later)
-parfor ix = 1:size(sID_all,1)   % loop over sections
+parfor ix = 1:count-1   % loop over sections
     %disp([sID_all{ix,1}{1} ' ' sID_all{ix,2}{1} ' ' num2str(ismontage(ix))]);
     % when loading point matches, load all available point
     % then filter them, and after that select points randomly to limit the size of

--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -31,12 +31,19 @@ if ~isfield(opts, 'Width')  % if not set, then assume FAFB
     opts.Width = 2160;
     opts.Height = 2560;
 end
+if ~isfield(opts, 'offset_x')
+  opts.offset_x = 0;
+  opts.offset_y = 0;
+end
+if ~isfield(opts, 'centre'), opts.centre = false; end
 if ~isfield(opts, 'inverse_dz')
     opts.inverse_dz = 1;
 end
 spmd
     warning('off', 'vision:obsolete:obsoleteFunctionality');
 end
+
+if ~isfield(opts, 'primenbr'), opts.primenbr = false; end
 
 if ~isfield(pm,'verbose')
     for i = 1:numel(pm)
@@ -56,58 +63,105 @@ else
 end
 ismontage = [];
 count  = 1;
+<<<<<<< HEAD
+
+if ~opts.primenbr
+  if ~opts.outside_group
+    sID_all = cell(numel(zu)*(opts.nbrs+1)-opts.nbrs*(opts.nbrs+1)/2,2);
+  end
+  for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
+			 %disp(['Setting up section: ' sID{ix}]);
+=======
 if ~opts.outside_group
     sID_all = cell(numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2,2);
 end
 for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
     %disp(['Setting up section: ' sID{ix}]);
+>>>>>>> 2c271c9cfc9f887c68309efc639307bf9f6a1b13
     sID_all{count,1} = sID{ix};
     sID_all{count,2} = sID{ix};
     ismontage(count) = 1;
     if opts.outside_group 
-        fac{count} = 1;
+      fac{count} = 1;
     else
-        fac(count) = 1;
+      fac(count) = 1;
     end
     count = count + 1;
     if opts.outside_group
-        %disp(['cross-layer: ' num2str(ix) ' ' sID{ix} ' -- ' num2str(nix) ' ' sID{ix+nix}]);
-        second_index = min(ix+opts.nbrs, numel(zu));
-        sID1 = sID{ix};
-        if ix~=second_index
-            sID_all{count,1} = sID1;
-            sID_all{count,2} = sID{second_index}; %what to do about reacquires
-            ismontage(count) = 0;
-            z_range = ix+1:second_index;
-            current_sID_range = cellfun(@(sIDs)(sIDs{:}), sID(z_range),'uniformOutput', false);
-            current_keys = strcat([sID1{1} '_'], current_sID_range);
-            current_values = opts.xs_weight./(z_range -ix + 1);
-            fac{count} = containers.Map(current_keys,current_values);
-            count = count + 1;
-        end
+%disp(['cross-layer: ' num2str(ix) ' ' sID{ix} ' -- ' num2str(nix) ' ' sID{ix+nix}]);
+      second_index = min(ix+opts.nbrs, numel(zu));
+      sID1 = sID{ix};
+      if ix~=second_index
+        sID_all{count,1} = sID1;
+        sID_all{count,2} = sID{second_index}; %what to do about reacquires
+        ismontage(count) = 0;
+        z_range = ix+1:second_index;
+        current_sID_range = cellfun(@(sIDs)(sIDs{:}), sID(z_range),'uniformOutput', false);
+        current_keys = strcat([sID1{1} '_'], current_sID_range);
+        current_values = opts.xs_weight./(z_range -ix + 1);
+        fac{count} = containers.Map(current_keys,current_values);
+        count = count + 1;
+      end
     else
-        for nix = 1:opts.nbrs
-            if (ix+nix)<=numel(zu)
-                %disp(['cross-layer: ' num2str(ix) ' ' sID{ix} ' -- ' num2str(nix) ' ' sID{ix+nix}]);
-                sID_all{count,1} = sID{ix};
-                sID_all{count,2} = sID{ix+nix};
-                ismontage(count) = 0;
-                if opts.inverse_dz
-                    fac(count) = opts.xs_weight/(nix+1);
-                else
-                    fac(count) = opts.xs_weight;
-                end
-                count = count + 1;
-            end
+      for nix = 1:opts.nbrs
+        if (ix+nix)<=numel(zu)
+%disp(['cross-layer: ' num2str(ix) ' ' sID{ix} ' -- ' num2str(nix) ' ' sID{ix+nix}]);
+          sID_all{count,1} = sID{ix};
+          sID_all{count,2} = sID{ix+nix};
+          ismontage(count) = 0;
+          if opts.inverse_dz
+            fac(count) = opts.xs_weight/(nix+1);
+          else
+            fac(count) = opts.xs_weight;
+          end
+          count = count + 1;
         end
+      end
     end
+  end
+  if ~opts.outside_group && count ~= numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2 + 1
+    sID_all = sID_all(1:count-1,1:2);
+  end
+else
+  if opts.outside_group
+    error('opts.primenbr can not be used with opts.outside_group')
+  end
+						 %Preallocate sID
+  sID_all = cell((numel(zu)-1) * opts.primenbr, 2); %will need to be
+						 %reduced
+  primes_plus_one = [1,primes(opts.nbrs)];
+  for ix = 1:numel(zu)
+    ismontage(count)=1;
+    for nix = primes_plus_one(1:opts.primenbr)
+      if (ix + nix) <= numel(zu)
+	sID_all{count,1} = sID{ix};
+	sID_all{count,2} = sID{ix+nix};
+	ismontage(count) = 0;
+	if opts.inverse_dz
+	  fac(count) = opts.xs_weight/(nix+1);
+	else
+	  fac(count) = opts.xs_weight;
+	end
+	count = count+1;
+      end
+    end
+    
+  end
+  sID_all = sID_all(1:count-1,1:2);	
 end
+<<<<<<< HEAD
+
+
+
+=======
 if ~opts.outside_group && count ~= numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2 +1
     sID_all = sID_all(1:count-1,1:2);
 end
+>>>>>>> 2c271c9cfc9f887c68309efc639307bf9f6a1b13
 % clear sID
 % % perform pm requests
 
+    disp('Loading point-matches from point-match database ....');
 if pm(end).verbose
     disp('Loading point-matches from point-match database ....');
 end
@@ -169,6 +223,18 @@ parfor ix = 1:size(sID_all,1)   % loop over sections
             pmm2 = pmm{2};
             pmm1 = pmm1(indx,:);
             pmm2 = pmm2(indx,:);
+	    pmm1(:,1) = pmm1(:,1) - opts.offset_x;
+	    pmm2(:,1) = pmm2(:,1) - opts.offset_x;
+	    pmm1(:,2) = pmm1(:,2) - opts.offset_y;
+	    pmm2(:,2) = pmm2(:,2) - opts.offset_y;
+	    
+	    if opts.centre
+	      pmm1(:,1) = pmm1(:,1) - (opts.Width)/2;
+	      pmm2(:,1) = pmm2(:,1) - (opts.Width)/2;
+	      pmm1(:,2) = pmm1(:,2) - (opts.Height)/2;
+	      pmm2(:,2) = pmm2(:,2) - (opts.Height)/2;
+	      
+	    end
             m(pmix,:) = {pmm1,pmm2};
             pmw = w{pmix};
             w{pmix} = pmw(indx);
@@ -185,7 +251,7 @@ parfor ix = 1:size(sID_all,1)   % loop over sections
         n(delix) = [];
         a(delix,:) = [];
     end
-    
+
     M(ix) = {m};
     adj(ix) = {a};
     W(ix) = {w};
@@ -265,6 +331,7 @@ parfor pmix = 1:size(M, 1)
             end
             del_ix(pmix) = pmix;
         end
+	
         W{pmix} = w(inlierIdx);
         np(pmix) = length(W{pmix});
     end
@@ -305,7 +372,6 @@ for pix = 1:size(M,1)
         end
 %         disp(['Section: ' num2str(L.z) ' -- Removing ' num2str(numel(delix)) ' point-match sets outside bounds']);
     end
-    
 end
 delix = [delix; find(res(:,2)>thresh)];
 delix = [delix; find(res(:,1)>thresh)];

--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -103,7 +103,7 @@ for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
     end
 end
 if ~opts.outside_group && count ~= numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2 +1
-    sID_all = sID_all(1:count-1,2);
+    sID_all = sID_all(1:count-1,1:2);
 end
 % clear sID
 % % perform pm requests

--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -56,6 +56,9 @@ else
 end
 ismontage = [];
 count  = 1;
+if ~opts.outside_group
+    sID_all = cell(numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2,2);
+end
 for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
     %disp(['Setting up section: ' sID{ix}]);
     sID_all{count,1} = sID{ix};

--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -102,8 +102,8 @@ for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
         end
     end
 end
-if ~opts.outside_group && count ~= numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2
-    sID_all = sID_all(1:count,2);
+if ~opts.outside_group && count ~= numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2 +1
+    sID_all = sID_all(1:count-1,2);
 end
 % clear sID
 % % perform pm requests

--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -70,11 +70,10 @@ if ~opts.primenbr
   end
   for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
 			 %disp(['Setting up section: ' sID{ix}]);
-if ~opts.outside_group
-    sID_all = cell(numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2,2);
-end
-for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
-    %disp(['Setting up section: ' sID{ix}]);
+    if ~opts.outside_group
+      sID_all = cell(numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2,2);
+    end
+
     sID_all{count,1} = sID{ix};
     sID_all{count,2} = sID{ix};
     ismontage(count) = 1;

--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -63,7 +63,6 @@ else
 end
 ismontage = [];
 count  = 1;
-<<<<<<< HEAD
 
 if ~opts.primenbr
   if ~opts.outside_group
@@ -71,13 +70,11 @@ if ~opts.primenbr
   end
   for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
 			 %disp(['Setting up section: ' sID{ix}]);
-=======
 if ~opts.outside_group
     sID_all = cell(numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2,2);
 end
 for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
     %disp(['Setting up section: ' sID{ix}]);
->>>>>>> 2c271c9cfc9f887c68309efc639307bf9f6a1b13
     sID_all{count,1} = sID{ix};
     sID_all{count,2} = sID{ix};
     ismontage(count) = 1;
@@ -149,15 +146,12 @@ else
   end
   sID_all = sID_all(1:count-1,1:2);	
 end
-<<<<<<< HEAD
 
 
 
-=======
 if ~opts.outside_group && count ~= numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2 +1
     sID_all = sID_all(1:count-1,1:2);
 end
->>>>>>> 2c271c9cfc9f887c68309efc639307bf9f6a1b13
 % clear sID
 % % perform pm requests
 


### PR DESCRIPTION
For large datasets, setting the headers for sID_all cell results in a very large speedup and the calculation of the number of entries is trivial.